### PR TITLE
README.md, setup.py 파일 내에 GitHub 주소 변경(404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 1. git 명령어를 사용해 yonafi를 다운로드 받습니다.
 
    ```console
-   # git clone https://github.com/yona/yona-install
+   # git clone https://github.com/yona-projects/yona-install
    ```
 
 1. 파이썬 가상환경을 만들고 진입합니다.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ dependency_links = []
 
 setup(
     name='yona',
-    url='https://github.com/yona/yona-install',
+    url='https://github.com/yona-projects/yona-install',
     version='1.0',
     description='요나 설치 프로그램',
     author='Ji-ho Persy Lee',


### PR DESCRIPTION
Readme 파일을 보고 따라하던 중 github 주소가 404라 변경했습니다.

변경내용 : 
git clone https://github.com/yona/yona-install -> git clone https://github.com/yona-projects/yona-install 